### PR TITLE
Kill the "U" mapping for redo

### DIFF
--- a/.vim/common_config/key_mappings.vim
+++ b/.vim/common_config/key_mappings.vim
@@ -1,9 +1,6 @@
 " get out of insert mode with cmd-i
   imap <D-i> <Esc>
 
-" redo with U
-  nmap U :redo<cr>
-
 " easy wrap toggling
   nmap <Leader>w :set wrap!<cr>
   nmap <Leader>W :set nowrap<cr>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Common practice is to symlink a folder containing your custom configuration file
 ## Key mappings (remember case matters!)
 
 * `CMD + i` - exit out of insert mode
-* `U` - redo
 * `<leader>w` - turn on line wrapping
 * `<leader>W` - turn off line wrapping
 * `<leader>ss` - save all buffers


### PR DESCRIPTION
Pull request was originally to kill the vim-repeat plugin because it stomped on our "U" mapping. Now it keeps the plugin and kills the mapping.
