### PR TITLE
Remove the showmarks plugin

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -118,15 +118,6 @@
     nmap <Leader>f :FufRenewCache<CR>
     nmap <Leader>T :FufTagWithCursorWord!<CR>
 
-" ShowMarks to visually show placement of marks in files
-  Bundle "git://github.com/garbas/vim-showmarks.git"
-    let showmarks_include = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-    highlight ShowMarksHLl gui=bold guibg=LightBlue guifg=Blue
-    highlight ShowMarksHLu gui=bold guibg=LightRed guifg=DarkRed
-    highlight ShowMarksHLo gui=bold guibg=LightYellow guifg=DarkYellow
-    highlight ShowMarksHLm gui=bold guibg=LightGreen guifg=DarkGreen
-
 
 " ZoomWin to fullscreen a particular buffer without losing others
   Bundle "git://github.com/vim-scripts/ZoomWin.git"

--- a/README.md
+++ b/README.md
@@ -131,21 +131,6 @@ regions in vim scripts, HTML or JavaScript in php code etc.
 * `gCc`        - Comment the current line
 
 
-## ShowMarks
-
-ShowMarks provides a visual representation of the location marks.
-Marks are useful for jumping back and forth between interesting points in a buffer, but can be hard to keep track of without any way to see where you have placed them.  ShowMarks hopefully makes life easier by placing a sign in the leftmost column of the buffer.  The sign indicates the label of the mark and its location.
-It can be toggled on and off and individual marks can be hidden(effectively removing them).
-
-By default the following keymappings are defined:
-
-* `<leader>mt` - Toggles ShowMarks on and off.
-* `<leader>mh` - Hides an individual mark.
-* `<leader>ma` - Hides all marks in the current buffer.
-* `<leader>mm` - Places the next available mark.
-
-ShowMarks requires that Vim is compiled with the +signs feature.
-
 ## Fugitive
 
 I'm not going to lie to you; fugitive.vim may very well be the best


### PR DESCRIPTION
I never use the showmarks plugin. If other people regularly use it, feel free to -1 this request. I want it gone because the side gutter where the marks appear is ugly and bothers me. I also frequently create marks accidentally, and I don't want the visual noise when that happens.
