### PR TITLE
Make :Tab comma only align the first comma on each line

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -91,7 +91,7 @@
         AddTabularPattern! hash            /=>/
         AddTabularPattern! chunks          / \S\+/l0
         AddTabularPattern! assignment      / = /l0
-        AddTabularPattern! comma           /,\zs /l0
+        AddTabularPattern! comma           /^[^,]*,/l1
         AddTabularPattern! colon           /:\zs /l0
         AddTabularPattern! options_hashes  /:\w\+ =>/
       endif
@@ -100,7 +100,7 @@
     autocmd VimEnter * call CustomTabularPatterns()
 
     " shortcut to align text with Tabular
-    map <Leader>a :Tabular<space>
+    map <Leader>a :Tabularize<space>
 
 
 " Fuzzy finder for quickling opening files / buffers


### PR DESCRIPTION
So that the following lines:

``` ruby
  scope :draft, where(:state => [nil, DRAFT])
  scope :omit, lambda { |o| where('id != ?', o.id) }
```

are aligned to this:

``` ruby
  scope :draft, where(:state => [nil, DRAFT])
  scope :omit,  lambda { |o| where('id != ?', o.id) }
```

instead of this:

``` ruby
  scope :draft, where(:state => [nil,         DRAFT])
  scope :omit,  lambda { |o| where('id != ?', o.id) }
```
