### PR TITLE
:Tabularize hash only aligns the first hashrocket on each line

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -88,7 +88,7 @@
     function! CustomTabularPatterns()
       if exists('g:tabular_loaded')
         AddTabularPattern! symbols         / :/l0
-        AddTabularPattern! hash            /=>/
+        AddTabularPattern! hash            /^[^>]*\zs=>/
         AddTabularPattern! chunks          / \S\+/l0
         AddTabularPattern! assignment      / = /l0
         AddTabularPattern! comma           /,\zs /l0


### PR DESCRIPTION
So that this:

``` ruby
  'provider' => 'twitter',
  'credentials' => { 'token' => 'asdf', 'secret' => 'qwer' },
  'user_info' => { 'nickname' => 'test_twitter', 'id' => '1234567' }
```

aligns like this:

``` ruby
  'provider'    => 'twitter',
  'credentials' => { 'token' => 'asdf', 'secret' => 'qwer' },
  'user_info'   => { 'nickname' => 'test_twitter', 'id' => '1234567' }
```

instead of this:

``` ruby
  'provider'    => 'twitter',
  'credentials' => { 'token'    => 'asdf', 'secret'     => 'qwer' },
  'user_info'   => { 'nickname' => 'test_twitter', 'id' => '1234567' }
```
