### PR TITLE
correctly set the filetype for .md files

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -64,9 +64,9 @@
 " Markdown syntax highlighting
   Bundle "git://github.com/tpope/vim-markdown.git"
     augroup mkd
-      autocmd BufRead *.mkd  set ai formatoptions=tcroqn2 comments=n:>
-      autocmd BufRead *.md  set ai formatoptions=tcroqn2 comments=n:>
-      autocmd BufRead *.markdown  set ai formatoptions=tcroqn2 comments=n:>
+      autocmd BufRead *.mkd      set ai formatoptions=tcroqn2 comments=n:> ft=markdown
+      autocmd BufRead *.md       set ai formatoptions=tcroqn2 comments=n:> ft=markdown
+      autocmd BufRead *.markdown set ai formatoptions=tcroqn2 comments=n:> ft=markdown
     augroup END
 
 


### PR DESCRIPTION
Without this fix, .md files are being opened with modula2 syntax highlighting.
