### PR TITLE
<C-P> remapping to <C-S-P>

### DIFF
--- a/.vim/common_config/key_mappings.vim
+++ b/.vim/common_config/key_mappings.vim
@@ -69,4 +69,4 @@
 
 " insert the path of currently edited file into a command
 " Command mode: Ctrl-P
-  cmap <C-P> <C-R>=expand("%:p:h") . "/" <cr>
+  cmap <C-S-P> <C-R>=expand("%:p:h") . "/" <cr>


### PR DESCRIPTION
I remapped Ctrl-P to Ctrl-Shift-P so the command still exists but no longer conflicts with the emacs navigation binding that are default in most OS X apps.
