### PR TITLE
Minor fixup - Remove stale plugin Color-Sampler

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -24,6 +24,7 @@
   Bundle "git://github.com/vim-scripts/ruby-matchit.git"
   Bundle "git://github.com/wgibbs/vim-irblack.git"
   Bundle "git://github.com/wavded/vim-stylus.git"
+  Bundle "git://github.com/kien/ctrlp.vim.git"
 
   Bundle "git://github.com/smerrill/vim-arduino.git"
     au BufNewFile,BufRead *.pde set filetype=arduino
@@ -124,23 +125,6 @@
 
     " shortcut to align text with Tabular
     map <Leader>a :Tabularize<space>
-
-
-" Fuzzy finder for quickling opening files / buffers
-  Bundle "git://github.com/clones/vim-fuzzyfinder.git"
-    let g:fuf_coveragefile_prompt = '>GoToFile[]>'
-    let g:fuf_coveragefile_exclude = '\v\~$|' .
-    \                                '\.(o|exe|dll|bak|swp|log|sqlite3|png|gif|jpg)$|' .
-    \                                '(^|[/\\])\.(hg|git|bzr|bundle)($|[/\\])|' .
-    \                                '(^|[/\\])(log|tmp|vendor|system|doc|coverage|build|generated|node_modules)($|[/\\])'
-
-    let g:fuf_keyOpenTabpage = '<D-CR>'
-
-    nmap <Leader>t :FufCoverageFile<CR>
-    nmap <Leader>b :FufBuffer<CR>
-    nmap <Leader>f :FufRenewCache<CR>
-    nmap <Leader>T :FufTagWithCursorWord!<CR>
-
 
 " ZoomWin to fullscreen a particular buffer without losing others
   Bundle "git://github.com/vim-scripts/ZoomWin.git"

--- a/README.md
+++ b/README.md
@@ -87,17 +87,16 @@ Common practice is to symlink a folder containing your custom configuration file
 * `Lidsa` - insert some lorem ipsum text
 * `rdebug` - insert ruby specfic debugger statement
 
-## FuzzyFinder
+## CtrlP
 
-Provides convenient ways to quickly reach the
-buffer/file/command/bookmark/tag you want. FuzzyFinder searches with the
-fuzzy/partial pattern to which it converted an entered pattern.
+* `<C-p>` to invoke CtrlP in find file mode
 
-* `<leader>t` - fuzzy find files
-* `<leader>b` - fuzzy find open buffers
-* `<leader>T` - use fuzzy finder to navigate via tags instead of built-in tag navigation
-* `<C-j>` - open selected item in window in horizontal split
-* `<C-k>` - open selected item in vertical split
+Once open
+
+* `<C-f>` and `<C-b>` to cycle between MRU, File and Buffer modes
+* `<C-d>` to swtich to filename only search instead of full path
+
+Uses the default keybinding, please refer to https://github.com/kien/ctrlp.vim for complete mappings
 
 ## Unimpaired
 


### PR DESCRIPTION
The plugin url has been changed. Instead of updating it though I
choose to remove it as we already have a ton of similar color
schemes committed with this project within the vim-config/.vim/colors
folder and hence this plugin seems unnecessary.
