### PR TITLE
Removes stale Color-Sampler-Pack plugin

### DIFF
--- a/.vim/common_config/plugin_config.vim
+++ b/.vim/common_config/plugin_config.vim
@@ -2,7 +2,6 @@
 " install plugins.
 
 " Plugins requiring no additional configuration or keymaps
-  Bundle "git://github.com/vim-scripts/Color-Sampler-Pack.git"
   Bundle "git://github.com/oscarh/vimerl.git"
   Bundle "git://github.com/tpope/vim-git.git"
   Bundle "git://github.com/harleypig/vcscommand.vim.git"


### PR DESCRIPTION
The plugin url has been changed. Instead of updating it though I
choose to remove it as we already have a ton of similar color
schemes committed with this project within the vim-config/.vim/colors
folder and hence this plugin seems unnecessary.
