### PR TITLE
Strips trailing whitespace w/out moving the cursor

### DIFF
--- a/.vim/common_config/functions.vim
+++ b/.vim/common_config/functions.vim
@@ -24,3 +24,18 @@ command! Tidy :%! tidy -indent -quiet -wrap 100
 
 " Align all colon-separated content (CSS rules) in a file
 command! AlignColons execute 'g/:/Tabularize colon' | noh
+
+" via: http://rails-bestpractices.com/posts/60-remove-trailing-whitespace
+" Strip trailing whitespace
+function! <SID>StripTrailingWhitespaces()
+    " Preparation: save last search, and cursor position.
+    let _s=@/
+    let l = line(".")
+    let c = col(".")
+    " Do the business:
+    %s/\s\+$//e
+    " Clean up: restore previous search history, and cursor position
+    let @/=_s
+    call cursor(l, c)
+endfunction
+command! StripTrailingWhitespaces call <SID>StripTrailingWhitespaces()

--- a/.vim/common_config/key_mappings.vim
+++ b/.vim/common_config/key_mappings.vim
@@ -43,7 +43,7 @@
   nnoremap vv `[V`]
 
 " clean up trailing whitespace
-  map <Leader>c :%s/\s\+$<cr>
+  map <Leader>c :StripTrailingWhitespaces<cr>
 
 " compress excess whitespace on current line
   map <Leader>e :s/\v(\S+)\s+/\1 /<cr>:nohl<cr>


### PR DESCRIPTION
Stripping whitespace currently moves the cursor to the last substitution, this saves the cursor location and resets it after the replacements.
