### PR TITLE
Stop shadowing vim default for text formatting

### DIFF
--- a/.vim/common_config/01_plugin_config.vim
+++ b/.vim/common_config/01_plugin_config.vim
@@ -89,7 +89,6 @@
     nmap ga :AgAdd!<space>
     nmap gn :cnext<CR>
     nmap gp :cprev<CR>
-    nmap gq :ccl<CR>
     nmap gl :cwindow<CR>
 
 


### PR DESCRIPTION
By default, `gq` will format text. This is actually really handy. I'm not normally an advocate of line length limits, but I like being able to write documentation without it running far off the right side of the screen. `gq` + motion will format the text to a sensible length. Try it today!